### PR TITLE
Adjust svgToTinyDataUri return type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-declare function svgToTinyDataUri(svgString: string): string;
+declare function svgToTinyDataUri(svgString: string): `data:image/svg+xml,${string}`;
 
 declare namespace svgToTinyDataUri {
   function toSrcset(svgString: string): string;


### PR DESCRIPTION
## What this does

This PR changes the return type of the main function from string to `data:image/svg+xml,${string}`.
The main function always adds `data:image/svg+xml,` at the beginning of the returned string and therefore this type changes definitely improves the type accuracy.

## Motivation

I'm using this package to generate placeholder images for my Next.js page.
The Next.js image component expects the placeholder string to start with `data:image/` and therefore throws an error when I pass a regular string to it. This could very well be useful when using other frameworks as well though.